### PR TITLE
Attempted Fix for Front-End Tests

### DIFF
--- a/src/client/jest.config.js
+++ b/src/client/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    testEnvironment: "jsdom",
+    moduleNameMapper: {
+      '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
+        '<rootDir>/__mocks__/fileMock.js',
+      '\\.(css|less)$': 'identity-obj-proxy',
+    },
+  };

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "jest --coverage --detectOpenHandles",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/client/src/components/SignUp.jsx
+++ b/src/client/src/components/SignUp.jsx
@@ -55,6 +55,7 @@ function SignUp() {
                       First Name
                       <br></br>
                       <input
+                        aria-label="firstname"
                         className="Input"
                         placeholder="Enter Your First Name"
                         name="firstname"

--- a/src/client/src/test/SignIn.test.js
+++ b/src/client/src/test/SignIn.test.js
@@ -3,10 +3,12 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SignIn from "../components/SignIn";
+import { BrowserRouter } from "react-router-dom";
+import '@testing-library/jest-dom';
 
 //Test to see if login title and placeholders were rendered correctly
 test("Sign in page header rendered correctly", () => {
-  render(<SignIn></SignIn>);
+  render(<BrowserRouter><SignIn /></BrowserRouter>);
   const title = screen.getByText(/Log in to your account/i);
   const emailplaceholder = screen.getByText(/email or username/i);
   const passwordplaceholder = screen.getByText(/password/i);

--- a/src/client/src/test/Signup.test.js
+++ b/src/client/src/test/Signup.test.js
@@ -2,10 +2,15 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import SignUp from "../components/SignUp";
+import '@testing-library/jest-dom';
+import { BrowserRouter } from "react-router-dom";
 
 test("page renders properly", () => {
-  render(<SignUp />);
-  const textboxElement = screen.getByRole("textbox");
+  render(<BrowserRouter><SignUp /></BrowserRouter>);
+  // Knowing there's more than 1 textbox, the test checks
+  // if there's a textbox which has an aria-label value set
+  // to firstname.
+  const textboxElement = screen.getByRole('textbox', {name: 'firstname'});
   const buttonElement = screen.getByRole("button");
   fireEvent.click(buttonElement);
   expect(textboxElement).toBeInTheDocument();


### PR DESCRIPTION
### Pull Request for Front-End Tests Fix
This pull requests attempts a fix for the front-end tests which were not working at the end of Sprint 1.
The fixes are described as follows:

- `npm run test` uses Jest instead of `react-scripts test`. Code coverage and open handles are added.
- Added new library `identity-obj-proxy` that fixes CSS imports.
- Placed each page inside of BrowserRouter
- Imported the jest-dom testing library, the `toBeInTheDocument()` function doesn't work without it.

Please post comments or questions if you have any! 🙂